### PR TITLE
It's make me crasy

### DIFF
--- a/src/main/java/se/bjurr/violations/comments/gitlab/lib/GitLabCommentsProvider.java
+++ b/src/main/java/se/bjurr/violations/comments/gitlab/lib/GitLabCommentsProvider.java
@@ -48,7 +48,7 @@ public class GitLabCommentsProvider implements CommentsProvider {
     try {
       project = gitlabApi.getProject(projectId);
     } catch (final Throwable e) {
-      throw new RuntimeException("Could not get project " + projectId);
+      throw new RuntimeException("Could not get project " + projectId, e);
     }
 
     final Integer mergeRequestId = violationCommentsToGitLabApi.getMergeRequestId();


### PR DESCRIPTION
I try to publish violations at GitLab, and always get this error without any explain, with every, damn it, new try, it's make me crazy.
If I just put to addresse bar manually http://{gitlab_url}/api/v4/projects/{project_id}/merge_requests/{request_id}/notes - all is right, but in plugin I still receive only "Could not get project"