### PR TITLE
Added test cases and fix for large new files

### DIFF
--- a/src/test/java/se/bjurr/violations/comments/gitlab/lib/GitLabCommentsProviderTest.java
+++ b/src/test/java/se/bjurr/violations/comments/gitlab/lib/GitLabCommentsProviderTest.java
@@ -4,6 +4,12 @@ import static se.bjurr.violations.comments.gitlab.lib.GitLabCommentsProvider.STA
 
 import org.assertj.core.api.SoftAssertions;
 import org.junit.Test;
+import se.bjurr.violations.comments.lib.model.ChangedFile;
+import se.bjurr.violations.lib.ViolationsLogger;
+
+import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.stream.IntStream;
 
 public class GitLabCommentsProviderTest {
 
@@ -29,5 +35,123 @@ public class GitLabCommentsProviderTest {
             GitLabCommentsProvider.getTitleWithWipPrefix(START_TITLE + "asdasd").orElse(null)) //
         .isNull();
     soft.assertAll();
+  }
+
+  @Test
+  public void shouldCommentAllLines() {
+    ChangedFile changedFile =
+        new ChangedFile(
+            "src/main/java/com/test/SomeClass.java",
+            Arrays.asList(
+                "@@ -0,0 +1,6 @@\n"
+                    + "+package com.test;\n"
+                    + "+\n"
+                    + "+public class SomeClass {\n"
+                    + "+\n"
+                    + "+\n"
+                    + "+}\n",
+                "src/main/java/com/test/SomeClass.java",
+                "src/main/java/com/test/SomeClass.java"));
+    ViolationCommentsToGitLabApi api = new ViolationCommentsToGitLabApi()
+        .setCommentOnlyChangedContent(false);
+    GitLabCommentsProvider gitlab = createGitLabCommentsProvider(api);
+    SoftAssertions soft = new SoftAssertions();
+    IntStream.rangeClosed(1, 6).forEach(line ->
+        soft.assertThat(gitlab.shouldComment(changedFile, line))
+            .as(Integer.toString(line))
+            .isTrue());
+    IntStream.rangeClosed(7, 100).forEach(line ->
+        soft.assertThat(gitlab.shouldComment(changedFile, line))
+            .as(Integer.toString(line))
+            .isTrue());
+    soft.assertAll();
+  }
+
+  @Test
+  public void shouldCommentOnlyChangedLines() {
+    ChangedFile changedFile =
+        new ChangedFile(
+            "src/main/java/com/test/SomeClass.java",
+            Arrays.asList(
+                "@@ -0,0 +1,6 @@\n"
+                    + "+package com.test;\n"
+                    + "+\n"
+                    + "+public class SomeClass {\n"
+                    + "+\n"
+                    + "+\n"
+                    + "+}\n",
+                "src/main/java/com/test/SomeClass.java",
+                "src/main/java/com/test/SomeClass.java"));
+    ViolationCommentsToGitLabApi api = new ViolationCommentsToGitLabApi().setCommentOnlyChangedContent(true);
+    GitLabCommentsProvider gitLabCommentsProvider = createGitLabCommentsProvider(api);
+    SoftAssertions soft = new SoftAssertions();
+    IntStream.rangeClosed(1, 6).forEach(line ->
+        soft.assertThat(gitLabCommentsProvider.shouldComment(changedFile, line))
+            .as(Integer.toString(line))
+            .isTrue());
+    IntStream.rangeClosed(7, 100).forEach(line ->
+        soft.assertThat(gitLabCommentsProvider.shouldComment(changedFile, line))
+            .as(Integer.toString(line))
+            .isFalse());
+    soft.assertAll();
+  }
+
+  @Test
+  public void shouldNotCommentLargeChanges() {
+    ChangedFile changedFile =
+        new ChangedFile(
+            "src/main/java/com/test/SomeClass.java",
+            Arrays.asList(
+                "",
+                "src/main/java/com/test/SomeClass.java",
+                "src/main/java/com/test/SomeClass.java",
+                "false",
+                "false",
+                "false"));
+    ViolationCommentsToGitLabApi api =
+        new ViolationCommentsToGitLabApi().setCommentOnlyChangedContent(true);
+    GitLabCommentsProvider gitLabCommentsProvider = createGitLabCommentsProvider(api);
+    SoftAssertions soft = new SoftAssertions();
+    IntStream.rangeClosed(1, 10).forEach(line ->
+        soft.assertThat(gitLabCommentsProvider.shouldComment(changedFile, line))
+            .as(Integer.toString(line))
+            .isFalse());
+    soft.assertAll();
+  }
+
+  @Test
+  public void shouldCommentLargeChangesIfNewFile() {
+    ChangedFile changedFile =
+        new ChangedFile(
+            "src/main/java/com/test/SomeClass.java",
+            Arrays.asList(
+                "",
+                "src/main/java/com/test/SomeClass.java",
+                "src/main/java/com/test/SomeClass.java",
+                "true",
+                "false",
+                "false"));
+    ViolationCommentsToGitLabApi api =
+        new ViolationCommentsToGitLabApi().setCommentOnlyChangedContent(true);
+    GitLabCommentsProvider gitLabCommentsProvider = createGitLabCommentsProvider(api);
+    SoftAssertions soft = new SoftAssertions();
+    IntStream.rangeClosed(1, 10).forEach(line ->
+        soft.assertThat(gitLabCommentsProvider.shouldComment(changedFile, line))
+            .as(Integer.toString(line))
+            .isTrue());
+    soft.assertAll();
+  }
+
+  private static GitLabCommentsProvider createGitLabCommentsProvider(ViolationCommentsToGitLabApi api) {
+    ViolationsLogger logger = new ViolationsLogger() {
+      @Override
+      public void log(Level level, String string) {
+      }
+
+      @Override
+      public void log(Level level, String string, Throwable t) {
+      }
+    };
+    return new GitLabCommentsProvider(logger, api, null, null, null, null);
   }
 }


### PR DESCRIPTION
Closes #13 

Had to do some constructor chaining in order to allow for the changes to be unit tested. The alternatives would be:

1. do no unit tests 
2. delegate to a static shouldComment method in GitLabCommentsProvider and test that
3. delegate to a  new shouldComment method in ViolationCommentsToGitLabApi and test that
4. add a dependency to a mocking library to bypass current constructor and test that way 
5. set up test depending on a real project and merge request off github

In the end, it's all a matter of preferences, whichever way we choose there would be arguments for and against. 