### PR TITLE
Added parameter and tests for the number of context lines to comment on

### DIFF
--- a/src/main/java/se/bjurr/violations/comments/gitlab/lib/GitLabCommentsProvider.java
+++ b/src/main/java/se/bjurr/violations/comments/gitlab/lib/GitLabCommentsProvider.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
+import java.util.stream.IntStream;
 import org.gitlab4j.api.Constants;
 import org.gitlab4j.api.Constants.TokenType;
 import org.gitlab4j.api.GitLabApi;
@@ -365,8 +366,12 @@ public class GitLabCommentsProvider implements CommentsProvider {
     if (patchString.isEmpty() && Boolean.parseBoolean(changedFile.getSpecifics().get(3))) {
       return true;
     }
-    return new PatchParserUtil(patchString) //
-        .isLineInDiff(line);
+    int contextLines = this.api.getCommentOnlyChangedContentContext();
+    PatchParserUtil patch = new PatchParserUtil(patchString);
+    return IntStream.rangeClosed(-contextLines, contextLines)
+        .filter(i -> patch.isLineInDiff(line + i) && !patch.findOldLine(line + i).isPresent())
+        .findAny()
+        .isPresent();
   }
 
   @Override

--- a/src/main/java/se/bjurr/violations/comments/gitlab/lib/ViolationCommentsToGitLabApi.java
+++ b/src/main/java/se/bjurr/violations/comments/gitlab/lib/ViolationCommentsToGitLabApi.java
@@ -4,6 +4,7 @@ import static java.util.Optional.ofNullable;
 import static se.bjurr.violations.comments.lib.CommentsCreator.createComments;
 
 import com.github.mustachejava.resolver.DefaultResolver;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.Reader;
 import java.util.Optional;
 import java.util.Scanner;
@@ -17,6 +18,7 @@ import se.bjurr.violations.lib.model.Violation;
 import se.bjurr.violations.lib.util.Utils;
 
 public class ViolationCommentsToGitLabApi {
+  @SuppressFBWarnings({"CRLF_INJECTION_LOGS"})
   private static class ViolationsLoggerJavaLogger implements ViolationsLogger {
     @Override
     public void log(final Level level, final String string) {
@@ -40,6 +42,7 @@ public class ViolationCommentsToGitLabApi {
   private boolean createCommentWithAllSingleFileComments = false;
   private boolean createSingleFileComments = false;
   private boolean commentOnlyChangedContent = false;
+  private int commentOnlyChangedContentContext;
   private String hostUrl;
   private String apiToken;
   private TokenType tokenType;
@@ -144,10 +147,20 @@ public class ViolationCommentsToGitLabApi {
     return this;
   }
 
+  public ViolationCommentsToGitLabApi setCommentOnlyChangedContentContext(
+      final int commentOnlyChangedContentContext) {
+    this.commentOnlyChangedContentContext = commentOnlyChangedContentContext;
+    return this;
+  }
+
   ViolationCommentsToGitLabApi() {}
 
   public boolean getCommentOnlyChangedContent() {
     return this.commentOnlyChangedContent;
+  }
+
+  public int getCommentOnlyChangedContentContext() {
+    return this.commentOnlyChangedContentContext;
   }
 
   public boolean getShouldCommentOnlyChangedFiles() {


### PR DESCRIPTION
Closes #15 

The changes are as follow:
1. Implemented commentOnlyChangedContentContext with similar effects to the Bitbucket implementation. 
2. Added tests to show the new behavior
3. Refactored older tests to remove some of the noise and make it clearer as to what we are verifying

Let me know if this is close to what you had in mind or we need to tweak it a bit. 